### PR TITLE
Add log file existence check

### DIFF
--- a/nft_report/README.md
+++ b/nft_report/README.md
@@ -1,4 +1,4 @@
-# nft_report.sh (v1.0)
+# nft_report.sh (v1.1)
 
 `nft_report.sh` is a simple Bash script to generate reports based on `nftables` log entries (with the `NFT-DROP:` prefix). It parses system log files such as `/var/log/syslog`, generates network abuse summaries, and can optionally send the report via email using `msmtp`.
 
@@ -13,6 +13,7 @@
   - Most targeted interfaces
   - Source IP to port mapping
 - Supports custom log file input (`--log`)
+- Fails early if the specified log file does not exist
 - Can send reports via SMTP-authenticated email (`--mail`)
 - Lightweight, no external dependencies beyond standard Linux tools
 

--- a/nft_report/nft_report.sh
+++ b/nft_report/nft_report.sh
@@ -52,6 +52,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Ensure the log file exists
+if [[ ! -f "$LOG" ]]; then
+  echo "Error: log file '$LOG' not found." >&2
+  exit 1
+fi
+
 # Generate the report and store it in a temporary file
 {
   echo "=== nftables Block Report ==="

--- a/nft_report/nft_report.sh
+++ b/nft_report/nft_report.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# nft_report.sh - version 1.0
+# nft_report.sh - version 1.1
 # Generates a report of nftables drops (with prefix NFT-DROP)
 # Optionally sends the report via email using msmtp
 # Supports --mail to send, --log to change log file, and --help for usage


### PR DESCRIPTION
## Summary
- avoid cryptic errors when the log file doesn't exist
- fail early with a clear message

## Testing
- `bash -n nft_report/nft_report.sh`
- `shellcheck nft_report/nft_report.sh`
- `bash nft_report/nft_report.sh --log /tmp/nonexistent.log | head`

------
https://chatgpt.com/codex/tasks/task_e_6841d62905348333ab042519ca18303f